### PR TITLE
[Feat] 게임 모드/난이도 설정 및 블럭 확률·속도 난이도별 적용, DoubleScoreItem 등 기능 개선

### DIFF
--- a/app/src/main/java/se/tetris/team5/gamelogic/block/BlockFactory.java
+++ b/app/src/main/java/se/tetris/team5/gamelogic/block/BlockFactory.java
@@ -4,15 +4,76 @@ import java.util.Random;
 import se.tetris.team5.blocks.*;
 
 public class BlockFactory {
-  private Random random;
+  /**
+   * 블럭 생성 난이도 (UI에서 동적으로 변경 가능)
+   */
+  public enum Difficulty {
+    NORMAL, EASY, HARD
+  }
 
+  private Random random;
+  private Difficulty difficulty = Difficulty.NORMAL;
+
+  /**
+   * 기본 생성자 (난이도: NORMAL, seed: 랜덤)
+   */
   public BlockFactory() {
     this.random = new Random();
   }
 
+  /**
+   * 난이도 지정 생성자 (seed: 랜덤)
+   */
+  public BlockFactory(Difficulty difficulty) {
+    this.random = new Random();
+    this.difficulty = difficulty;
+  }
+
+  /**
+   * 난이도 설정 (UI에서 호출)
+   */
+  public void setDifficulty(Difficulty difficulty) {
+    this.difficulty = difficulty;
+  }
+
+  /**
+   * 현재 난이도 반환 (UI에서 조회용)
+   */
+  public Difficulty getDifficulty() {
+    return this.difficulty;
+  }
+
+  /**
+   * 랜덤 시드(Seed) 재설정 (UI에서 seed 고정 플레이 등 활용 가능)
+   */
+  public void setRandomSeed(long seed) {
+    this.random = new Random(seed);
+  }
+
   public Block createRandomBlock() {
-    int blockType = random.nextInt(7);
-    return createBlock(blockType);
+    int[] weights;
+    // 블럭 순서: I, J, L, Z, S, T, O
+    switch (difficulty) {
+      case EASY:
+        weights = new int[] { 12, 10, 10, 10, 10, 10, 10 }; // I만 20% 더 높음
+        break;
+      case HARD:
+        weights = new int[] { 8, 10, 10, 10, 10, 10, 10 }; // I만 20% 낮음
+        break;
+      case NORMAL:
+      default:
+        weights = new int[] { 10, 10, 10, 10, 10, 10, 10 }; // 모두 동일
+    }
+    int total = 0;
+    for (int w : weights)
+      total += w;
+    int r = random.nextInt(total);
+    int idx = 0;
+    while (r >= weights[idx]) {
+      r -= weights[idx];
+      idx++;
+    }
+    return createBlock(idx);
   }
 
   /**
@@ -44,6 +105,9 @@ public class BlockFactory {
     }
   }
 
+  /**
+   * 랜덤 시드를 현재 시간으로 재설정 (UI에서 '새로고침' 등 활용 가능)
+   */
   public void refreshRandomSeed() {
     this.random = new Random(System.currentTimeMillis());
   }

--- a/app/src/main/java/se/tetris/team5/gamelogic/scoring/GameScoring.java
+++ b/app/src/main/java/se/tetris/team5/gamelogic/scoring/GameScoring.java
@@ -4,97 +4,127 @@ package se.tetris.team5.gamelogic.scoring;
  * 게임 점수와 레벨을 관리하는 클래스
  */
 public class GameScoring {
-    private int currentScore;
-    private int level;
-    private int linesCleared;
-    private int dropSpeed;
-    
-    private static final int POINTS_PER_LINE = 100;
-    private static final int POINTS_PER_TETRIS = 800;
-    private static final int SOFT_DROP_POINTS = 1;
-    private static final int HARD_DROP_MULTIPLIER = 2;
-    private static final int INITIAL_DROP_SPEED = 1000; // 1초
-    private static final int LEVEL_SPEED_DECREASE = 100; // 레벨당 속도 증가
-    
-    public GameScoring() {
-        reset();
+  private int currentScore;
+  private int level;
+  private int linesCleared;
+  private int dropSpeed;
+
+  private static final int POINTS_PER_LINE = 100;
+  private static final int POINTS_PER_TETRIS = 800;
+  private static final int SOFT_DROP_POINTS = 1;
+  private static final int HARD_DROP_MULTIPLIER = 2;
+  private static final int INITIAL_DROP_SPEED = 1000; // 1초
+  private static final int BASE_LEVEL_SPEED_DECREASE = 100; // Normal 기준 레벨당 속도 증가
+  private int levelSpeedDecrease = BASE_LEVEL_SPEED_DECREASE;
+
+  /**
+   * 난이도에 따라 레벨당 속도 증가폭을 조정합니다.
+   * 
+   * @param difficulty BlockFactory.Difficulty
+   */
+  public void setDifficulty(se.tetris.team5.gamelogic.block.BlockFactory.Difficulty difficulty) {
+    switch (difficulty) {
+      case EASY:
+        levelSpeedDecrease = (int) Math.round(BASE_LEVEL_SPEED_DECREASE * 0.8); // 20% 덜 증가
+        break;
+      case HARD:
+        levelSpeedDecrease = (int) Math.round(BASE_LEVEL_SPEED_DECREASE * 1.2); // 20% 더 증가
+        break;
+      case NORMAL:
+      default:
+        levelSpeedDecrease = BASE_LEVEL_SPEED_DECREASE;
     }
-    
-    /**
-     * 점수 시스템을 초기화합니다
-     */
-    public void reset() {
-        currentScore = 0;
-        level = 1;
-        linesCleared = 0;
-        dropSpeed = INITIAL_DROP_SPEED;
+    // 난이도 변경 시 현재 레벨에 맞춰 속도 재계산
+    updateDropSpeed();
+  }
+
+  public GameScoring() {
+    reset();
+  }
+
+  /**
+   * 점수 시스템을 초기화합니다
+   */
+  public void reset() {
+    currentScore = 0;
+    level = 1;
+    linesCleared = 0;
+    dropSpeed = INITIAL_DROP_SPEED;
+  }
+
+  /**
+   * 점수를 추가합니다
+   */
+  public void addPoints(int points) {
+    currentScore += points;
+  }
+
+  /**
+   * 줄 클리어에 따른 점수 계산
+   */
+  public void addLinesCleared(int lines) {
+    linesCleared += lines;
+
+    // 줄 수에 따른 점수 계산
+    int points = 0;
+    switch (lines) {
+      case 1:
+        points = POINTS_PER_LINE * level;
+        break;
+      case 2:
+        points = POINTS_PER_LINE * 3 * level;
+        break;
+      case 3:
+        points = POINTS_PER_LINE * 5 * level;
+        break;
+      case 4:
+        points = POINTS_PER_TETRIS * level;
+        break;
+      default:
+        points = lines * POINTS_PER_LINE * level;
     }
-    
-    /**
-     * 점수를 추가합니다
-     */
-    public void addPoints(int points) {
-        currentScore += points;
+
+    currentScore += points;
+
+    // 레벨 업 체크 (10줄마다 레벨 증가)
+    int newLevel = (linesCleared / 10) + 1;
+    if (newLevel > level) {
+      level = newLevel;
+      updateDropSpeed();
     }
-    
-    /**
-     * 줄 클리어에 따른 점수 계산
-     */
-    public void addLinesCleared(int lines) {
-        linesCleared += lines;
-        
-        // 줄 수에 따른 점수 계산
-        int points = 0;
-        switch (lines) {
-            case 1:
-                points = POINTS_PER_LINE * level;
-                break;
-            case 2:
-                points = POINTS_PER_LINE * 3 * level;
-                break;
-            case 3:
-                points = POINTS_PER_LINE * 5 * level;
-                break;
-            case 4:
-                points = POINTS_PER_TETRIS * level;
-                break;
-            default:
-                points = lines * POINTS_PER_LINE * level;
-        }
-        
-        currentScore += points;
-        
-        // 레벨 업 체크 (10줄마다 레벨 증가)
-        int newLevel = (linesCleared / 10) + 1;
-        if (newLevel > level) {
-            level = newLevel;
-            updateDropSpeed();
-        }
-    }
-    
-    /**
-     * 하드 드롭 점수 추가
-     */
-    public void addHardDropPoints(int distance) {
-        currentScore += distance * HARD_DROP_MULTIPLIER;
-    }
-    
-    /**
-     * 드롭 속도 업데이트
-     */
-    private void updateDropSpeed() {
-        dropSpeed = Math.max(100, INITIAL_DROP_SPEED - ((level - 1) * LEVEL_SPEED_DECREASE));
-    }
-    
-    /**
-     * 현재 타이머 간격 반환 (밀리초)
-     */
-    public int getTimerInterval() {
-        return dropSpeed;
-    }
-    
-    // Getters
-    public int getCurrentScore() { return currentScore; }
-    public int getLevel() { return level; }
-    public int getLinesCleared() { return linesCleared; }
+  }
+
+  /**
+   * 하드 드롭 점수 추가
+   */
+  public void addHardDropPoints(int distance) {
+    currentScore += distance * HARD_DROP_MULTIPLIER;
+  }
+
+  /**
+   * 드롭 속도 업데이트
+   */
+  private void updateDropSpeed() {
+    dropSpeed = Math.max(100, INITIAL_DROP_SPEED - ((level - 1) * levelSpeedDecrease));
+  }
+
+  /**
+   * 현재 타이머 간격 반환 (밀리초)
+   */
+  public int getTimerInterval() {
+    return dropSpeed;
+  }
+
+  // Getters
+  public int getCurrentScore() {
+    return currentScore;
+  }
+
+  public int getLevel() {
+    return level;
+  }
+
+  public int getLinesCleared() {
+    return linesCleared;
+  }
 }

--- a/app/src/test/java/se/tetris/team5/gamelogic/block/BlockFactoryProbabilityTest.java
+++ b/app/src/test/java/se/tetris/team5/gamelogic/block/BlockFactoryProbabilityTest.java
@@ -1,0 +1,90 @@
+package se.tetris.team5.gamelogic.block;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import se.tetris.team5.blocks.Block;
+
+public class BlockFactoryProbabilityTest {
+  private static final int TRIALS = 10000; // 충분히 큰 반복 횟수
+  private static final double TOLERANCE = 0.05; // ±5%
+
+  @Test
+  public void testNormalProbability() {
+    BlockFactory factory = new BlockFactory(BlockFactory.Difficulty.NORMAL);
+    int[] counts = new int[7];
+    for (int i = 0; i < TRIALS; i++) {
+      Block b = factory.createRandomBlock();
+      counts[getBlockIndex(b)]++;
+    }
+    double expected = 1.0 / 7.0;
+    for (int i = 0; i < 7; i++) {
+      double actual = counts[i] / (double) TRIALS;
+      assertEquals("NORMAL: block " + i + " freq", expected, actual, TOLERANCE);
+    }
+  }
+
+  @Test
+  public void testEasyProbability() {
+    BlockFactory factory = new BlockFactory(BlockFactory.Difficulty.EASY);
+    int[] counts = new int[7];
+    for (int i = 0; i < TRIALS; i++) {
+      Block b = factory.createRandomBlock();
+      counts[getBlockIndex(b)]++;
+    }
+    // I: 12/72, others: 10/72
+    double expectedI = 12.0 / 72.0;
+    double expectedOther = 10.0 / 72.0;
+    for (int i = 0; i < 7; i++) {
+      double actual = counts[i] / (double) TRIALS;
+      if (i == 0) {
+        assertEquals("EASY: I freq", expectedI, actual, TOLERANCE);
+      } else {
+        assertEquals("EASY: block " + i + " freq", expectedOther, actual, TOLERANCE);
+      }
+    }
+  }
+
+  @Test
+  public void testHardProbability() {
+    BlockFactory factory = new BlockFactory(BlockFactory.Difficulty.HARD);
+    int[] counts = new int[7];
+    for (int i = 0; i < TRIALS; i++) {
+      Block b = factory.createRandomBlock();
+      counts[getBlockIndex(b)]++;
+    }
+    // I: 8/68, others: 10/68
+    double expectedI = 8.0 / 68.0;
+    double expectedOther = 10.0 / 68.0;
+    for (int i = 0; i < 7; i++) {
+      double actual = counts[i] / (double) TRIALS;
+      if (i == 0) {
+        assertEquals("HARD: I freq", expectedI, actual, TOLERANCE);
+      } else {
+        assertEquals("HARD: block " + i + " freq", expectedOther, actual, TOLERANCE);
+      }
+    }
+  }
+
+  // I=0, J=1, L=2, Z=3, S=4, T=5, O=6
+  private int getBlockIndex(Block b) {
+    String name = b.getClass().getSimpleName();
+    switch (name) {
+      case "IBlock":
+        return 0;
+      case "JBlock":
+        return 1;
+      case "LBlock":
+        return 2;
+      case "ZBlock":
+        return 3;
+      case "SBlock":
+        return 4;
+      case "TBlock":
+        return 5;
+      case "OBlock":
+        return 6;
+      default:
+        throw new IllegalArgumentException("Unknown block: " + name);
+    }
+  }
+}

--- a/app/src/test/java/se/tetris/team5/gamelogic/scoring/GameScoringSpeedTest.java
+++ b/app/src/test/java/se/tetris/team5/gamelogic/scoring/GameScoringSpeedTest.java
@@ -1,0 +1,59 @@
+package se.tetris.team5.gamelogic.scoring;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import se.tetris.team5.gamelogic.block.BlockFactory;
+
+public class GameScoringSpeedTest {
+  @Test
+  public void testNormalSpeedIncrease() {
+    GameScoring scoring = new GameScoring();
+    scoring.setDifficulty(BlockFactory.Difficulty.NORMAL);
+    // 1레벨: 1000, 2레벨: 900, 3레벨: 800, ...
+    assertEquals(1000, scoring.getTimerInterval());
+    for (int i = 1; i <= 9; i++)
+      scoring.addLinesCleared(1); // 9줄
+    assertEquals(1000, scoring.getTimerInterval()); // 아직 1레벨
+    scoring.addLinesCleared(1); // 10줄째
+    assertEquals(900, scoring.getTimerInterval()); // 2레벨
+    for (int i = 1; i <= 10; i++)
+      scoring.addLinesCleared(1); // 20줄째
+    assertEquals(800, scoring.getTimerInterval()); // 3레벨
+  }
+
+  @Test
+  public void testEasySpeedIncrease() {
+    GameScoring scoring = new GameScoring();
+    scoring.setDifficulty(BlockFactory.Difficulty.EASY);
+    assertEquals(1000, scoring.getTimerInterval());
+    for (int i = 1; i <= 10; i++)
+      scoring.addLinesCleared(1); // 10줄
+    assertEquals(920, scoring.getTimerInterval()); // 2레벨
+    for (int i = 1; i <= 10; i++)
+      scoring.addLinesCleared(1); // 20줄
+    assertEquals(840, scoring.getTimerInterval()); // 3레벨
+  }
+
+  @Test
+  public void testHardSpeedIncrease() {
+    GameScoring scoring = new GameScoring();
+    scoring.setDifficulty(BlockFactory.Difficulty.HARD);
+    assertEquals(1000, scoring.getTimerInterval());
+    for (int i = 1; i <= 10; i++)
+      scoring.addLinesCleared(1); // 10줄
+    assertEquals(880, scoring.getTimerInterval()); // 2레벨
+    for (int i = 1; i <= 10; i++)
+      scoring.addLinesCleared(1); // 20줄
+    assertEquals(760, scoring.getTimerInterval()); // 3레벨
+  }
+
+  @Test
+  public void testSpeedMinimum100ms() {
+    GameScoring scoring = new GameScoring();
+    scoring.setDifficulty(BlockFactory.Difficulty.HARD);
+    // 1000 - 120*8 = 40, 최소 100ms로 제한
+    for (int i = 1; i <= 90; i++)
+      scoring.addLinesCleared(1);
+    assertEquals(100, scoring.getTimerInterval());
+  }
+}


### PR DESCRIPTION
# 🧩 PR 요약
- 게임 모드/난이도 설정 구조 개선, 난이도별 블럭 생성 확률 및 낙하 속도 적용, 점수 2배 아이템 등 기능 추가 및 테스트

---

## ✨ 변경 내용
- BlockFactory: 난이도별 블럭 생성 확률 적용, set/getDifficulty, setRandomSeed 등 UI/엔진 연동 메서드 추가
- GameEngine: setGameMode, setDifficulty로 게임 모드/난이도 통합 관리, BlockFactory/GameScoring에 일괄 반영
- GameScoring: setDifficulty로 난이도별 낙하 속도 증가폭 적용 (Normal: 100ms, Easy: 80ms, Hard: 120ms)
- DoubleScoreItem(점수 2배 아이템) 구현 및 자동 효과 적용, 관련 테스트(DoubleScoreItemTest) 작성
- BlockFactoryProbabilityTest, GameScoringSpeedTest 등 자동화 테스트로 확률/속도/효과 검증

---

## ✅ 체크리스트
- [x] 코드 스타일 및 규칙 준수
- [x] 관련 테스트 통과
- [x] 난이도/모드 변경 시 하위 컴포넌트에 정상 반영

---

## 💬 리뷰 참고사항
- [ ] 게임 모드/난이도 설정 구조
  - [ ] GameEngine에서 setGameMode, setDifficulty로 통합 관리
  - [ ] BlockFactory, GameScoring 등 하위 객체에 일괄 반영
  - [ ] UI 연동 시 GameEngine의 setter만 호출하면 됨
- [ ] 난이도별 블럭 생성 확률/낙하 속도
  - [ ] BlockFactory: NORMAL(동일), EASY(I블럭 20%↑), HARD(I블럭 20%↓)
  - [ ] GameScoring: 레벨업마다 Normal 100ms, Easy 80ms, Hard 120ms씩 빨라짐(최소 100ms)
  - [ ] BlockFactoryProbabilityTest, GameScoringSpeedTest로 자동 검증
- [ ] DoubleScoreItem(점수 2배 아이템)
  - [ ] 줄 삭제로 아이템이 사라질 때 효과 자동 발동, 20초간 유지 후 해제
  - [ ] 점수 2배 적용은 applyDoubleScore(int)에서 처리, isDoubleScoreActive()로 확인
  - [ ] 관련 테스트 코드 존재

---

## 📎 관련 이슈
- closes #41

---

### 참고: 게임 모드/난이도 설정 및 연동법

#### 1. 게임 모드/난이도 설정 코드 예시

```java
// GameEngine 인스턴스 생성 후, UI 등에서 아래처럼 호출
gameEngine.setGameMode(GameEngine.GameMode.ITEM); // 또는 NORMAL
gameEngine.setDifficulty(BlockFactory.Difficulty.HARD); // 또는 NORMAL, EASY