### PR TITLE
[Fix] 무게추 아이템 출현시 점수 로직 정지

### DIFF
--- a/app/src/main/java/se/tetris/team5/gamelogic/GameEngine.java
+++ b/app/src/main/java/se/tetris/team5/gamelogic/GameEngine.java
@@ -116,7 +116,10 @@ public class GameEngine {
 
     if (movementManager.moveDown(currentBlock, x, y)) {
       y++;
-      gameScoring.addPoints(applyDoubleScore(1)); // 소프트 드롭 점수
+      // 무게추 블록(WBlock)일 때는 점수를 부여하지 않음
+      if (!(currentBlock instanceof se.tetris.team5.blocks.WBlock)) {
+        gameScoring.addPoints(applyDoubleScore(1)); // 소프트 드롭 점수
+      }
       boardManager.placeBlock(currentBlock, x, y);
       return true;
     } else {
@@ -214,7 +217,11 @@ public class GameEngine {
     boardManager.eraseBlock(currentBlock, x, y);
     int dropDistance = movementManager.hardDrop(currentBlock, x, y);
     y = movementManager.getDropPosition(currentBlock, x, y);
-    gameScoring.addHardDropPoints(applyDoubleScore(dropDistance));
+    
+    // 무게추 블록(WBlock)일 때는 하드드롭 점수를 부여하지 않음
+    if (!(currentBlock instanceof se.tetris.team5.blocks.WBlock)) {
+      gameScoring.addHardDropPoints(applyDoubleScore(dropDistance));
+    }
 
     boardManager.placeBlock(currentBlock, x, y);
     java.util.List<se.tetris.team5.items.Item> removedItems = new java.util.ArrayList<>();

--- a/app/src/main/java/se/tetris/team5/gamelogic/block/BlockFactory.java
+++ b/app/src/main/java/se/tetris/team5/gamelogic/block/BlockFactory.java
@@ -80,7 +80,7 @@ public class BlockFactory {
       r -= weights[idx];
       idx++;
     }
-    return createBlock(0);
+    return createBlock(idx);
   }
 
   /**

--- a/app/src/main/java/se/tetris/team5/items/Every10LinesItemGrantPolicy.java
+++ b/app/src/main/java/se/tetris/team5/items/Every10LinesItemGrantPolicy.java
@@ -17,7 +17,7 @@ public class Every10LinesItemGrantPolicy implements ItemGrantPolicy {
 
     // 10줄마다 아이템 부여
     if (context.totalClearedLines > 0 &&
-        context.totalClearedLines >= lastGrantLine + 2) {
+        context.totalClearedLines >= lastGrantLine + 10) {
 
       int w = block.width();
       int h = block.height();


### PR DESCRIPTION
🧩 PR 요약

- 무게추 아이템 출현 시 모든 점수 로직 정지
---

✨ 변경 내용
- [x] 기존 무게추 아이템 출현해도 점수가 올라갔는데 이를 삭제
- [x] 기존 무게추 아이템 하드드롭시 점수가 올라갔는데 이를 삭제
---
close #49 