### PR TITLE
chore : github action CI 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,121 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master, "feature/**", "release/**"]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            java-version: "21"
+          - os: macos-latest
+            java-version: "21"
+          - os: windows-latest
+            java-version: "21"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ matrix.java-version }}
+          cache: "gradle"
+
+      - name: Cache gradle wrapper & caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ env.GRADLE_CACHE_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Ensure Gradle wrapper is executable (UNIX)
+        if: runner.os != 'Windows'
+        run: chmod +x ./gradlew
+
+      - name: Build (compile & test)
+        # Use platform-appropriate gradle command
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            .\gradlew.bat --no-daemon build
+          else
+            ./gradlew --no-daemon build
+          fi
+        shell: bash
+
+      - name: Create fat JAR
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            .\gradlew.bat --no-daemon fatJar
+          else
+            ./gradlew --no-daemon fatJar
+          fi
+        shell: bash
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tetris-artifacts-${{ matrix.os }}
+          path: |
+            app/build/libs/*.jar
+            app/build/reports/tests/test
+
+  package-windows:
+    name: Optional Windows packaging (jpackage)
+    runs-on: windows-latest
+    needs: build
+    if: matrix.os == 'windows-latest' || true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK (for jpackage)
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Build fat JAR
+        run: .\gradlew.bat --no-daemon fatJar
+
+      - name: Attempt jpackage (may require extra setup)
+        run: |
+          echo "Note: jpackage may not be available on hosted runners or may require additional runtime files."
+          echo "If you need a guaranteed Windows EXE build with bundled JRE, consider a self-hosted Windows runner or GitHub Releases with a release workflow."
+        shell: cmd
+
+  publish-artifacts:
+    name: Publish combined artifacts
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download artifacts (all runners)
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List downloaded artifacts
+        run: ls -la artifacts || dir artifacts
+
+      - name: Upload combined artifact for release
+        uses: actions/upload-artifact@v4
+        with:
+          name: tetris-all-artifacts
+          path: artifacts
+# Notes:
+# - This workflow runs build & tests on Ubuntu, macOS and Windows using Java 21 (Temurin).
+# - Gradle cache is configured via setup-java cache and an additional actions/cache step.
+# - Windows-native packaging with jpackage is non-trivial on hosted runners; consider self-hosted runner for reproducible EXE creation.
+# - To add GitHub Releases publish or code-signing, create a separate 'release' workflow that runs on tags and uses 'actions/create-release' and 'sbc/sign' or other signing actions with secrets.


### PR DESCRIPTION
main을 타겟으로 한 Pull Request를 올릴시 트리거 작동.
각 플랫폼 (window, mac, linux) 환경에서 빌드 테스트.
결과물과 로그 보는곳

- GitHub → 리포지토리 → Actions 탭 → 해당 워크플로우 실행 선택
   - 각 matrix job(예: Build on macos-latest) 클릭 → Steps 클릭 → 각 step의 상세 로그 확인
   - Upload build artifacts에서 업로드된 JAR와 테스트 리포트는 Actions 실행 내에서 다운로드 가능(Artifacts 섹션)
- publish-artifacts job은 모든 OS에서 업로드된 artifact를 모아 다시 묶음