### PR TITLE
[feat] 대전 모드 공격 블럭 구현

### DIFF
--- a/app/src/main/java/se/tetris/team5/gamelogic/GameEngine.java
+++ b/app/src/main/java/se/tetris/team5/gamelogic/GameEngine.java
@@ -42,6 +42,9 @@ public class GameEngine {
   // listeners to notify UI or other observers about state changes (e.g., next
   // block spawned)
   private List<Runnable> listeners = new ArrayList<>();
+  
+  // 대전모드: 블럭 고정 후 콜백 (공격 블럭 적용용)
+  private Runnable onBlockFixedCallback = null;
 
   // Last cleared rows (for UI to consume and animate). Cleared row indices are
   // 0..HEIGHT-1
@@ -191,6 +194,21 @@ public class GameEngine {
       // 블록 높이 패널티 체크
       checkHeightPenalty();
 
+      // 대전모드: 블럭 고정 후 콜백 호출 (공격 블럭 적용)
+      System.out.println("[GameEngine] moveBlockDown - 블럭 고정됨, 콜백 체크: " + (onBlockFixedCallback != null));
+      if (onBlockFixedCallback != null) {
+        System.out.println("[GameEngine] 블럭 고정 완료 - 콜백 호출 시작");
+        try {
+          onBlockFixedCallback.run();
+          System.out.println("[GameEngine] 콜백 실행 완료");
+        } catch (Exception e) {
+          System.err.println("[GameEngine] 콜백 실행 중 오류: " + e.getMessage());
+          e.printStackTrace();
+        }
+      } else {
+        System.out.println("[GameEngine] 콜백이 null입니다!");
+      }
+
       spawnNextBlock();
       return false;
     }
@@ -297,6 +315,21 @@ public class GameEngine {
 
     // 블록 높이 패널티 체크
     checkHeightPenalty();
+
+    // 대전모드: 블럭 고정 후 콜백 호출 (공격 블럭 적용)
+    System.out.println("[GameEngine] hardDrop - 블럭 고정됨, 콜백 체크: " + (onBlockFixedCallback != null));
+    if (onBlockFixedCallback != null) {
+      System.out.println("[GameEngine] 하드드롭 블럭 고정 완료 - 콜백 호출 시작");
+      try {
+        onBlockFixedCallback.run();
+        System.out.println("[GameEngine] 콜백 실행 완료");
+      } catch (Exception e) {
+        System.err.println("[GameEngine] 콜백 실행 중 오류: " + e.getMessage());
+        e.printStackTrace();
+      }
+    } else {
+      System.out.println("[GameEngine] 콜백이 null입니다!");
+    }
 
     spawnNextBlock();
     return true;
@@ -633,6 +666,17 @@ public class GameEngine {
    */
   public long getGameStartTime() {
     return gameStartTime;
+  }
+
+  /**
+   * 대전모드: 블럭 고정 후 콜백 설정
+   * 
+   * @param callback 블럭이 고정된 직후 호출될 콜백
+   */
+  public void setOnBlockFixedCallback(Runnable callback) {
+    System.out.println("[GameEngine] setOnBlockFixedCallback 호출됨 - callback null 여부: " + (callback == null));
+    this.onBlockFixedCallback = callback;
+    System.out.println("[GameEngine] 콜백 저장 완료");
   }
 
   /**

--- a/app/src/main/java/se/tetris/team5/screens/battle.java
+++ b/app/src/main/java/se/tetris/team5/screens/battle.java
@@ -168,6 +168,10 @@ public class battle extends JPanel implements KeyListener {
     player1Panel = new PlayerGamePanel();
     player2Panel = new PlayerGamePanel();
 
+    // 대전모드: 상대방 패널 서로 연결 (공격 블럭 전송용)
+    player1Panel.setOpponentPanel(player2Panel);
+    player2Panel.setOpponentPanel(player1Panel);
+
     // 게임 모드 설정 (NORMAL, ITEM, TIMELIMIT)
     if ("ITEM".equals(battleMode)) {
       player1Panel.getGameEngine().setGameMode(GameMode.ITEM);


### PR DESCRIPTION
## 🧩 PR 요약
- 대전 모드 공격 블럭 구현

---

## ✨ 변경 내용
- 공격한 블럭이 상대방의 넘어간 블럭 표시부분에 나타나는지 확인 부탁드립니다.
- 2줄 이상일 때만 공격이 가능한지 확인 부탁드립니다.
- 공격한 블럭들이 아래에서부터 추가되는지 확인 부탁드립니다.
- 줄을 삭제시킨 원인이 되는 블럭을 제외하고 공격 블럭이 추가되는지 확인 부탁드립니다.
- 공격시킨 줄이 누적으로 10줄이 초과됐을 때 공격이 비활성화되는지 확인 부탁드립니다.

---

## ✅ 체크리스트
- [x] 공격 블럭 잘 적용 되는지 확인바람

---

## 💬 리뷰 참고사항
- feat/#88 브렌치 가져가서 대전 모드에 공격블럭이 잘 적용되는지 확인 부탁드립니다

---

## 📎 관련 이슈
- closes #88 