### PR TITLE
[hotfix] createRandomBlock 메서드 매개변수 삭제로 인한 코드 수정

### DIFF
--- a/app/src/main/java/se/tetris/team5/items/Every10LinesItemGrantPolicy.java
+++ b/app/src/main/java/se/tetris/team5/items/Every10LinesItemGrantPolicy.java
@@ -17,7 +17,7 @@ public class Every10LinesItemGrantPolicy implements ItemGrantPolicy {
 
     // 10줄마다 아이템 부여
     if (context.totalClearedLines > 0 &&
-        context.totalClearedLines >= lastGrantLine + 2) {
+        context.totalClearedLines >= lastGrantLine + 10) {
 
       int w = block.width();
       int h = block.height();


### PR DESCRIPTION
## 🧩 PR 요약
- createRandomBlock 메서드의 매개변수가 삭제되어 실패하던 빌드를 수정합니다.

---

## ✨ 변경 내용
  - itemModeOnly 변수 삭제
  - GameEngine 클래스 createRandomBlock메서드 매개변수 삭제

---

## ✅ 체크리스트
- [x] 빌드가 성공하는지 확인합니다.
- [x] GameEngine 클래스 내부에 itemModeOnly변수가 삭제되었는지 확인합니다.
- [x] GameEngine 클래스 내부에 createRandomBlock 메서드의 매개변수가 삭제되었는지 확인합니다.

---

## 📎 관련 이슈
- closes #105 